### PR TITLE
Added support for modern Doxygen Awesome style documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ option(QUARTER_USE_QT5 "Prefer Qt5 over Qt4 if available" ON)
 option(QUARTER_BUILD_PLUGIN "Build Quarter plugin for QT Designer" ON)
 option(QUARTER_BUILD_EXAMPLES "Build Quarter example applications" ON)
 option(QUARTER_BUILD_DOCUMENTATION "Build and install API documentation (requires Doxygen)." OFF)
+option(QUARTER_BUILD_AWESOME_DOCUMENTATION "Build and install API documentation in new modern style (requires Doxygen)." OFF)
 cmake_dependent_option(QUARTER_BUILD_INTERNAL_DOCUMENTATION "Document internal code not part of the API." OFF "QUARTER_BUILD_DOCUMENTATION" OFF)
 cmake_dependent_option(QUARTER_BUILD_DOC_MAN "Build Quarter man pages." OFF "QUARTER_BUILD_DOCUMENTATION" OFF)
 cmake_dependent_option(QUARTER_BUILD_DOC_QTHELP "Build QtHelp documentation." OFF "QUARTER_BUILD_DOCUMENTATION" OFF)
@@ -76,6 +77,7 @@ report_prepare(
   QUARTER_BUILD_PLUGIN
   QUARTER_BUILD_EXAMPLES
   QUARTER_BUILD_DOCUMENTATION
+  QUARTER_BUILD_AWESOME_DOCUMENTATION
   QUARTER_BUILD_INTERNAL_DOCUMENTATION
   QUARTER_BUILD_DOC_MAN
   QUARTER_BUILD_DOC_QTHELP
@@ -285,6 +287,58 @@ if(QUARTER_BUILD_DOCUMENTATION)
     message(STATUS "CMAKE_INSTALL_MANDIR ${CMAKE_INSTALL_MANDIR}")
   endif()
 endif()
+
+
+# ############################################################################
+# Add a target to generate new modern API documentation with Doxygen
+# ############################################################################
+
+if(QUARTER_BUILD_AWESOME_DOCUMENTATION)
+  find_package(Doxygen)
+  if(NOT DOXYGEN_FOUND)
+    message(FATAL_ERROR "Doxygen is needed to build the documentation.")
+  endif()
+
+  if(NOT "${Coin_DOC_DIR}" STREQUAL "")
+    get_filename_component(_coin_versioned_dir ${Coin_DOC_DIR} NAME)
+    set(DOXYGEN_TAGFILES_AWESOME "${Coin_DOC_DIR}/html/Coin.tag=../../${_coin_versioned_dir}/html_awesome")
+  endif()
+
+# ############################################################################
+# Setup documentation options
+# ############################################################################
+  set(GENERATE_HTMLHELP NO)
+  set(DOXYGEN_GENERATE_MAN NO)
+  set(GENERATE_QHP NO)
+  set(GENERATE_TREEVIEW YES)
+  set(DOXYGEN_INTERNAL_DOCS NO)
+  set(DOXYGEN_EXTRACT_PRIVATE NO)
+  set(DOXYGEN_WARN_IF_UNDOCUMENTED YES)
+  set(DOXYGEN_EXCLUDE)
+
+  set(DOXYFILE_AWESOME "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_awesome")
+  set(DOXYGEN_OUTPUT_AWESOME "${CMAKE_BINARY_DIR}/html_awesome/index.html")
+  configure_file("${CMAKE_SOURCE_DIR}/docs/quarter.doxygen.awesome.cmake.in" ${DOXYFILE_AWESOME} @ONLY)
+
+# ############################################################################
+# Setup documentation targets
+# ############################################################################
+  add_custom_command(
+    OUTPUT ${DOXYGEN_OUTPUT_AWESOME}
+    COMMAND ${CMAKE_COMMAND} -E echo_append "Generating modern API documentation with Doxygen "
+    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYFILE_AWESOME}
+    COMMAND ${CMAKE_COMMAND} -E echo "done."
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+    DEPENDS ${DOXYFILE_AWESOME}
+  )
+  add_custom_target(documentation_awesome ALL DEPENDS ${DOXYGEN_OUTPUT_AWESOME})
+
+# ############################################################################
+# Install built documentation files
+# ############################################################################
+  install(DIRECTORY "${CMAKE_BINARY_DIR}/html_awesome" DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT documentation REGEX ".*\\.(chm|qch)" EXCLUDE)
+endif()
+
 
 # ############################################################################
 # Install headers

--- a/docs/quarter.doxygen.awesome.cmake.in
+++ b/docs/quarter.doxygen.awesome.cmake.in
@@ -1,0 +1,365 @@
+# Doxyfile 1.8.14
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+DOXYFILE_ENCODING      = UTF-8
+PROJECT_NAME           = @PROJECT_NAME@
+PROJECT_NUMBER         = @PROJECT_VERSION@
+PROJECT_BRIEF          = A Coin3D Library
+PROJECT_LOGO           = @CMAKE_SOURCE_DIR@/docs/doxygen/Coin_logo.png
+OUTPUT_DIRECTORY       =
+CREATE_SUBDIRS         = NO
+ALLOW_UNICODE_NAMES    = NO
+OUTPUT_LANGUAGE        = English
+BRIEF_MEMBER_DESC      = YES
+REPEAT_BRIEF           = YES
+ABBREVIATE_BRIEF       =
+ALWAYS_DETAILED_SEC    = NO
+INLINE_INHERITED_MEMB  = NO
+FULL_PATH_NAMES        = NO
+STRIP_FROM_PATH        =
+STRIP_FROM_INC_PATH    =
+SHORT_NAMES            = NO
+JAVADOC_AUTOBRIEF      = YES
+QT_AUTOBRIEF           = NO
+MULTILINE_CPP_IS_BRIEF = NO
+INHERIT_DOCS           = YES
+SEPARATE_MEMBER_PAGES  = NO
+TAB_SIZE               = 8
+ALIASES                = "COIN=<a href=https://github.com/coin3d/coin><b>Coin</b></a>" \
+                         "QT=<a href=http://www.qt.io><b>Qt</b></a>"
+TCL_SUBST              =
+OPTIMIZE_OUTPUT_FOR_C  = NO
+OPTIMIZE_OUTPUT_JAVA   = NO
+OPTIMIZE_FOR_FORTRAN   = NO
+OPTIMIZE_OUTPUT_VHDL   = NO
+EXTENSION_MAPPING      =
+MARKDOWN_SUPPORT       = YES
+TOC_INCLUDE_HEADINGS   = 5
+AUTOLINK_SUPPORT       = YES
+BUILTIN_STL_SUPPORT    = NO
+CPP_CLI_SUPPORT        = NO
+SIP_SUPPORT            = NO
+IDL_PROPERTY_SUPPORT   = YES
+DISTRIBUTE_GROUP_DOC   = NO
+GROUP_NESTED_COMPOUNDS = NO
+SUBGROUPING            = YES
+INLINE_GROUPED_CLASSES = NO
+INLINE_SIMPLE_STRUCTS  = NO
+TYPEDEF_HIDES_STRUCT   = NO
+LOOKUP_CACHE_SIZE      = 0
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+EXTRACT_ALL            = NO
+EXTRACT_PRIVATE        = @DOXYGEN_EXTRACT_PRIVATE@
+EXTRACT_PACKAGE        = NO
+EXTRACT_STATIC         = NO
+EXTRACT_LOCAL_CLASSES  = NO
+EXTRACT_LOCAL_METHODS  = NO
+EXTRACT_ANON_NSPACES   = YES
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+HIDE_FRIEND_COMPOUNDS  = YES
+HIDE_IN_BODY_DOCS      = NO
+INTERNAL_DOCS          = @DOXYGEN_INTERNAL_DOCS@
+CASE_SENSE_NAMES       = YES
+HIDE_SCOPE_NAMES       = NO
+HIDE_COMPOUND_REFERENCE= NO
+SHOW_INCLUDE_FILES     = YES
+SHOW_GROUPED_MEMB_INC  = NO
+FORCE_LOCAL_INCLUDES   = NO
+INLINE_INFO            = YES
+SORT_MEMBER_DOCS       = NO
+SORT_BRIEF_DOCS        = NO
+SORT_MEMBERS_CTORS_1ST = NO
+SORT_GROUP_NAMES       = NO
+SORT_BY_SCOPE_NAME     = NO
+STRICT_PROTO_MATCHING  = NO
+GENERATE_TODOLIST      = NO
+GENERATE_TESTLIST      = NO
+GENERATE_BUGLIST       = YES
+GENERATE_DEPRECATEDLIST= YES
+ENABLED_SECTIONS       =
+MAX_INITIALIZER_LINES  = 30
+SHOW_USED_FILES        = YES
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
+FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
+CITE_BIB_FILES         =
+#---------------------------------------------------------------------------
+# Configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+QUIET                  = YES
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = @DOXYGEN_WARN_IF_UNDOCUMENTED@
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = NO
+WARN_AS_ERROR          = NO
+WARN_FORMAT            = "$file:$line: $text"
+WARN_LOGFILE           =
+#---------------------------------------------------------------------------
+# Configuration options related to the input files
+#---------------------------------------------------------------------------
+INPUT                  = @CMAKE_SOURCE_DIR@/include/Quarter/Basic.h \
+                         @CMAKE_SOURCE_DIR@/include/Quarter/QuarterWidget.h \
+                         @CMAKE_SOURCE_DIR@/include/Quarter/Quarter.h \
+                         @CMAKE_SOURCE_DIR@/include/Quarter/eventhandlers/EventFilter.h \
+                         @CMAKE_SOURCE_DIR@/include/Quarter/eventhandlers/DragDropHandler.h \
+                         @CMAKE_SOURCE_DIR@/include/Quarter/eventhandlers/FocusHandler.h \
+                         @CMAKE_SOURCE_DIR@/include/Quarter/devices/InputDevice.h \
+                         @CMAKE_SOURCE_DIR@/include/Quarter/devices/Keyboard.h \
+                         @CMAKE_SOURCE_DIR@/include/Quarter/devices/Mouse.h \
+                         @CMAKE_SOURCE_DIR@/src/Quarter/Quarter.cpp \
+                         @CMAKE_SOURCE_DIR@/src/Quarter/QuarterWidget.cpp \
+                         @CMAKE_SOURCE_DIR@/src/Quarter/InputDevice.cpp \
+                         @CMAKE_SOURCE_DIR@/src/Quarter/Keyboard.cpp \
+                         @CMAKE_SOURCE_DIR@/src/Quarter/Mouse.cpp \
+                         @CMAKE_SOURCE_DIR@/src/Quarter/EventFilter.cpp \
+                         @CMAKE_SOURCE_DIR@/src/Quarter/DragDropHandler.cpp \
+                         @CMAKE_SOURCE_DIR@/src/Quarter/FocusHandler.cpp \
+                         @CMAKE_SOURCE_DIR@/src/plugins/QuarterWidgetPlugin.h \
+                         @CMAKE_SOURCE_DIR@/src/plugins/QuarterWidgetPlugin.cpp \
+                         @CMAKE_SOURCE_DIR@/src/examples/minimal.cpp \
+                         @CMAKE_SOURCE_DIR@/src/examples/directui.cpp \
+                         @CMAKE_SOURCE_DIR@/src/examples/dynamicui.cpp \
+                         @CMAKE_SOURCE_DIR@/src/examples/inheritui.cpp \
+                         @CMAKE_SOURCE_DIR@/src/examples/examiner.cpp \
+                         @CMAKE_SOURCE_DIR@/src/examples/mdi.cpp
+INPUT_ENCODING         = UTF-8
+FILE_PATTERNS          =
+RECURSIVE              = NO
+EXCLUDE                = @DOXYGEN_EXCLUDE@
+EXCLUDE_SYMLINKS       = NO
+EXCLUDE_PATTERNS       =
+EXCLUDE_SYMBOLS        = @DOXYGEN_EXCLUDE_SYMBOLS@
+EXAMPLE_PATH           =
+EXAMPLE_PATTERNS       = *
+EXAMPLE_RECURSIVE      = NO
+IMAGE_PATH             = @CMAKE_SOURCE_DIR@/docs/doxygen
+INPUT_FILTER           =
+FILTER_PATTERNS        =
+FILTER_SOURCE_FILES    = NO
+FILTER_SOURCE_PATTERNS =
+USE_MDFILE_AS_MAINPAGE =
+#---------------------------------------------------------------------------
+# Configuration options related to source browsing
+#---------------------------------------------------------------------------
+SOURCE_BROWSER         = NO
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = YES
+REFERENCED_BY_RELATION = NO
+REFERENCES_RELATION    = NO
+REFERENCES_LINK_SOURCE = YES
+SOURCE_TOOLTIPS        = YES
+USE_HTAGS              = NO
+VERBATIM_HEADERS       = YES
+CLANG_ASSISTED_PARSING = NO
+CLANG_OPTIONS          =
+CLANG_COMPILATION_DATABASE_PATH                                        = 0
+#---------------------------------------------------------------------------
+# Configuration options related to the alphabetical class index
+#---------------------------------------------------------------------------
+ALPHABETICAL_INDEX     = YES
+COLS_IN_ALPHA_INDEX    = 5
+IGNORE_PREFIX          = So \
+                         Sb \
+                         cc_
+#---------------------------------------------------------------------------
+# Configuration options related to the HTML output
+#---------------------------------------------------------------------------
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html_awesome
+HTML_FILE_EXTENSION    = .html
+HTML_HEADER            = @CMAKE_SOURCE_DIR@/docs/doxygen-awesome-css/doxygen-custom/header.html
+HTML_FOOTER            = 
+HTML_STYLESHEET        =
+HTML_EXTRA_STYLESHEET  = @CMAKE_SOURCE_DIR@/docs/doxygen-awesome-css/doxygen-awesome.css \
+                         @CMAKE_SOURCE_DIR@/docs/doxygen-awesome-css/doxygen-custom/custom.css \
+                         @CMAKE_SOURCE_DIR@/docs/doxygen-awesome-css/doxygen-awesome-sidebar-only.css \
+                         @CMAKE_SOURCE_DIR@/docs/doxygen-awesome-css/doxygen-awesome-sidebar-only-darkmode-toggle.css \
+                         @CMAKE_SOURCE_DIR@/docs/doxygen-awesome-css/doxygen-custom/custom-alternative.css
+HTML_EXTRA_FILES       = @CMAKE_SOURCE_DIR@/docs/doxygen-awesome-css/doxygen-awesome-darkmode-toggle.js \
+                         @CMAKE_SOURCE_DIR@/docs/doxygen-awesome-css/doxygen-awesome-fragment-copy-button.js \
+                         @CMAKE_SOURCE_DIR@/docs/doxygen-awesome-css/doxygen-awesome-paragraph-link.js \
+                         @CMAKE_SOURCE_DIR@/docs/doxygen-awesome-css/doxygen-custom/toggle-alternative-theme.js \
+                         @CMAKE_SOURCE_DIR@/docs/doxygen-awesome-css/doxygen-awesome-interactive-toc.js \
+                         @CMAKE_SOURCE_DIR@/docs/doxygen-awesome-css/doxygen-awesome-tabs.js
+HTML_COLORSTYLE        = LIGHT
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_TIMESTAMP         = YES
+HTML_DYNAMIC_MENUS     = YES
+HTML_DYNAMIC_SECTIONS  = NO
+HTML_INDEX_NUM_ENTRIES = 100
+GENERATE_DOCSET        = NO
+DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_BUNDLE_ID       = org.doxygen.Project
+DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
+DOCSET_PUBLISHER_NAME  = Publisher
+GENERATE_HTMLHELP      = @GENERATE_HTMLHELP@
+CHM_FILE               = @PROJECT_NAME@-@PROJECT_VERSION_MAJOR@.chm
+HHC_LOCATION           = "@HHC_PROGRAM@"
+GENERATE_CHI           = NO
+CHM_INDEX_ENCODING     =
+BINARY_TOC             = NO
+TOC_EXPAND             = NO
+GENERATE_QHP           = @GENERATE_QHP@
+QCH_FILE               = @PROJECT_NAME@-@PROJECT_VERSION_MAJOR@.qch
+QHP_NAMESPACE          = org.Coin3d.@PROJECT_NAME@
+QHP_VIRTUAL_FOLDER     = Coin3d
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHG_LOCATION           = "@QHG_LOCATION@"
+GENERATE_ECLIPSEHELP   = NO
+ECLIPSE_DOC_ID         = org.doxygen.Project
+DISABLE_INDEX          = NO
+GENERATE_TREEVIEW      = YES
+ENUM_VALUES_PER_LINE   = 4
+TREEVIEW_WIDTH         = 250
+EXT_LINKS_IN_WINDOW    = NO
+FORMULA_FONTSIZE       = 10
+FORMULA_TRANSPARENT    = YES
+USE_MATHJAX            = NO
+MATHJAX_FORMAT         = HTML-CSS
+MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_EXTENSIONS     =
+MATHJAX_CODEFILE       =
+SEARCHENGINE           = YES
+SERVER_BASED_SEARCH    = NO
+EXTERNAL_SEARCH        = NO
+SEARCHENGINE_URL       =
+SEARCHDATA_FILE        = searchdata.xml
+EXTERNAL_SEARCH_ID     =
+EXTRA_SEARCH_MAPPINGS  =
+#---------------------------------------------------------------------------
+# Configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+GENERATE_LATEX         = NO
+LATEX_OUTPUT           = latex
+LATEX_CMD_NAME         = latex
+MAKEINDEX_CMD_NAME     = makeindex
+COMPACT_LATEX          = NO
+PAPER_TYPE             = a4wide
+EXTRA_PACKAGES         =
+LATEX_HEADER           =
+LATEX_FOOTER           =
+LATEX_EXTRA_STYLESHEET =
+LATEX_EXTRA_FILES      =
+PDF_HYPERLINKS         = NO
+USE_PDFLATEX           = NO
+LATEX_BATCHMODE        = NO
+LATEX_HIDE_INDICES     = NO
+LATEX_SOURCE_CODE      = NO
+LATEX_BIB_STYLE        = plain
+LATEX_TIMESTAMP        = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the RTF output
+#---------------------------------------------------------------------------
+GENERATE_RTF           = NO
+RTF_OUTPUT             = rtf
+COMPACT_RTF            = NO
+RTF_HYPERLINKS         = NO
+RTF_STYLESHEET_FILE    =
+RTF_EXTENSIONS_FILE    =
+RTF_SOURCE_CODE        = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the man page output
+#---------------------------------------------------------------------------
+GENERATE_MAN           = @DOXYGEN_GENERATE_MAN@
+MAN_OUTPUT             = man
+MAN_EXTENSION          = .3
+MAN_SUBDIR             =
+MAN_LINKS              = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the XML output
+#---------------------------------------------------------------------------
+GENERATE_XML           = NO
+XML_OUTPUT             = xml
+XML_PROGRAMLISTING     = YES
+#---------------------------------------------------------------------------
+# Configuration options related to the DOCBOOK output
+#---------------------------------------------------------------------------
+GENERATE_DOCBOOK       = NO
+DOCBOOK_OUTPUT         = docbook
+DOCBOOK_PROGRAMLISTING = NO
+#---------------------------------------------------------------------------
+# Configuration options for the AutoGen Definitions output
+#---------------------------------------------------------------------------
+GENERATE_AUTOGEN_DEF   = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the Perl module output
+#---------------------------------------------------------------------------
+GENERATE_PERLMOD       = NO
+PERLMOD_LATEX          = NO
+PERLMOD_PRETTY         = YES
+PERLMOD_MAKEVAR_PREFIX =
+#---------------------------------------------------------------------------
+# Configuration options related to the preprocessor
+#---------------------------------------------------------------------------
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = NO
+SEARCH_INCLUDES        = YES
+INCLUDE_PATH           = @CMAKE_BINARY_DIR@/include \
+                         @CMAKE_SOURCE_DIR@/include \
+                         @CMAKE_SOURCE_DIR@/src/plugins
+INCLUDE_FILE_PATTERNS  = .h \
+                         .h.in
+PREDEFINED             = DOXYGEN_SKIP_THIS \
+                         HAVE_CONFIG_H= \
+                         QUARTER_DLL_API=
+EXPAND_AS_DEFINED      =
+SKIP_FUNCTION_MACROS   = YES
+#---------------------------------------------------------------------------
+# Configuration options related to external references
+#---------------------------------------------------------------------------
+TAGFILES               = @DOXYGEN_TAGFILES@
+GENERATE_TAGFILE       = @CMAKE_BINARY_DIR@/html/@PROJECT_NAME@-@PROJECT_VERSION_MAJOR@.tag
+ALLEXTERNALS           = NO
+EXTERNAL_GROUPS        = YES
+EXTERNAL_PAGES         = YES
+PERL_PATH              =
+#---------------------------------------------------------------------------
+# Configuration options related to the dot tool
+#---------------------------------------------------------------------------
+CLASS_DIAGRAMS         = YES
+MSCGEN_PATH            =
+DIA_PATH               =
+HIDE_UNDOC_RELATIONS   = NO
+HAVE_DOT               = NO
+DOT_NUM_THREADS        = 0
+DOT_FONTNAME           = Helvetica
+DOT_FONTSIZE           = 10
+DOT_FONTPATH           =
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES
+GROUP_GRAPHS           = YES
+UML_LOOK               = NO
+UML_LIMIT_NUM_FIELDS   = 10
+TEMPLATE_RELATIONS     = YES
+INCLUDE_GRAPH          = YES
+INCLUDED_BY_GRAPH      = YES
+CALL_GRAPH             = NO
+CALLER_GRAPH           = NO
+GRAPHICAL_HIERARCHY    = YES
+DIRECTORY_GRAPH        = YES
+DOT_IMAGE_FORMAT       = png
+INTERACTIVE_SVG        = NO
+DOT_PATH               =
+DOTFILE_DIRS           =
+MSCFILE_DIRS           =
+DIAFILE_DIRS           =
+PLANTUML_JAR_PATH      =
+PLANTUML_CFG_FILE      =
+PLANTUML_INCLUDE_PATH  =
+DOT_GRAPH_MAX_NODES    = 50
+MAX_DOT_GRAPH_DEPTH    = 0
+DOT_TRANSPARENT        = NO
+DOT_MULTI_TARGETS      = NO
+GENERATE_LEGEND        = YES
+DOT_CLEANUP            = YES


### PR DESCRIPTION
The following pull request is meant as a proposal to add modern, responsive and mobile friendly style to Quarter library documentation that supports dark and light style. The doxygen style is based on the [Doxygen Awesome](https://jothepro.github.io/doxygen-awesome-css/) project.

While the Coin3D libraries are up to date and usable with the latest Qt6 version, the documentation looks really old and outdated - like from the 90s. This gives the impression of an old and outdated project. Especially browsing the documentation on mobile devices is a pain.

If the pull request will be accepted after a discussion and some changes, I'm ready to update also the other coin libraries.

To avoid breaking the current documentation or the creation of CHM and QCH help files, I added a completely new build target **documentation_awesome**.