### PR TITLE
Added function setupDefaultCursors()

### DIFF
--- a/include/Quarter/QuarterWidget.h
+++ b/include/Quarter/QuarterWidget.h
@@ -146,6 +146,7 @@ public:
   void resetNavigationModeFile(void);
   void setNavigationModeFile(const QUrl & url = QUrl(DEFAULT_NAVIGATIONFILE));
   const QUrl & navigationModeFile(void) const;
+  void setupDefaultCursors();
 
   void setContextMenuEnabled(bool yes);
   bool contextMenuEnabled(void) const;

--- a/src/Quarter/QuarterWidget.cpp
+++ b/src/Quarter/QuarterWidget.cpp
@@ -996,6 +996,24 @@ QuarterWidget::resetNavigationModeFile(void) {
   this->setNavigationModeFile(QUrl());
 }
 
+
+/**
+ * Sets up the default cursors for the widget.
+ */
+void QuarterWidget::setupDefaultCursors()
+{
+    this->setStateCursor("interact", Qt::ArrowCursor);
+    this->setStateCursor("idle", Qt::OpenHandCursor);
+#if QT_VERSION >= 0x040200
+    this->setStateCursor("rotate", Qt::ClosedHandCursor);
+#endif
+    this->setStateCursor("pan", Qt::SizeAllCursor);
+    this->setStateCursor("zoom", Qt::SizeVerCursor);
+    this->setStateCursor("dolly", Qt::SizeVerCursor);
+    this->setStateCursor("seek", Qt::CrossCursor);
+    this->setStateCursor("spin", Qt::OpenHandCursor);
+}
+
 /*!
   Sets a navigation mode file. Supports the schemes "coin" and "file"
 
@@ -1084,16 +1102,7 @@ QuarterWidget::setNavigationModeFile(const QUrl & url)
     // set up default cursors for the examiner navigation states
     //FIXME: It may be overly restrictive to not do this for arbitrary
     //navigation systems? - BFG 20090117
-    this->setStateCursor("interact", Qt::ArrowCursor);
-    this->setStateCursor("idle", Qt::OpenHandCursor);
-#if QT_VERSION >= 0x040200
-    this->setStateCursor("rotate", Qt::ClosedHandCursor);
-#endif
-    this->setStateCursor("pan", Qt::SizeAllCursor);
-    this->setStateCursor("zoom", Qt::SizeVerCursor);
-    this->setStateCursor("dolly", Qt::SizeVerCursor);
-    this->setStateCursor("seek", Qt::CrossCursor);
-    this->setStateCursor("spin", Qt::OpenHandCursor);
+    setupDefaultCursors();
   }
 }
 


### PR DESCRIPTION
The pull request adds the public function `setupDefaultCursors()`. If somene provides its own navigation XML file via `setNavigationModeFile()`, that only has some small modifications, then the default cursors are not setup. Making this function public allows the user the setup all cursors quickly with a single function call.