### PR TITLE
Fixed bug in InteractionMode and improved it

### DIFF
--- a/src/Quarter/InteractionMode.h
+++ b/src/Quarter/InteractionMode.h
@@ -66,12 +66,15 @@ private:
   bool keyPressEvent(QKeyEvent * event);
   bool keyReleaseEvent(QKeyEvent * event);
   bool focusOutEvent(QFocusEvent * event);
+  void updateNavigationState();
 
   QCursor prevcursor;
   QuarterWidget * quarterwidget;
   bool altkeydown;
   SoEventManager::NavigationState prevnavstate;
   bool isenabled;
+  bool ison;
+  bool isinteractive;
 };
 
 }}} // namespace


### PR DESCRIPTION
When using the the InteractionMode, whe noticed the following problem / bug:

- in our software the user can toggle the interaction mode via a checkable action
- this action calls the `setOn()` function of InteractionMode
- if the interaction mode is on and the user presses the **ALT** key, then the event manager remains in NO_NAVIGATION state because of the backed up previous state:

The problem is the following code in `setOn()`:

```c++
  if (on) {
    this->altkeydown = true;
    this->prevnavstate = eventmanager->getNavigationState();
    this->prevcursor = this->quarterwidget->cursor();
    this->quarterwidget->setCursor(this->quarterwidget->stateCursor("interact"));
    eventmanager->setNavigationState(SoEventManager::NO_NAVIGATION);
  } else {
    this->altkeydown = false;
    this->quarterwidget->setCursor(this->prevcursor);
    eventmanager->setNavigationState(this->prevnavstate);
  }
```

To reproduce this, do the following steps:

- activate interactive mode via setOn(true) call
- press and release the ALT key
- deactivate interactive mode via setOn(false) call

The event manager will remain in NO_NAVIGATION state.

To fix this I use different variables to track the on, altkey and interactive state. After the change, the **ALT** key works as a toggle switch. If it is pressed, then the other mode is activated. That means, if the widget is in navigation mode, **ALT** activates the interactive mode as long as pressed and if the widget is in interactive mode, pressing the ALT key temporary activates the navigation mode.