### PR TITLE
Implemented workaround for Qt bug QTBUG-91556 - reversed QWheelEvent axis when ALT key is pressed

### DIFF
--- a/src/Quarter/Mouse.cpp
+++ b/src/Quarter/Mouse.cpp
@@ -159,10 +159,19 @@ MouseP::mouseWheelEvent(QWheelEvent * event)
   // the wheel was rotated forwards away from the user; a negative
   // value indicates that the wheel was rotated backwards toward the
   // user.
+
 #if QT_VERSION >= 0x050700
-  if (event->angleDelta().y() > 0)
+  // this is a workaround for QTBUG-91556
+  // the ALT key reverses the wheel event axis - that means, if ALT key is
+  // pressed, the X axis is used for the wheel event, otherwise the Y axis
+  int AngleDelta = event->angleDelta().y();
+  if (this->mousebutton->wasAltDown() && AngleDelta == 0)
+  {
+    AngleDelta = event->angleDelta().x();
+  }
+  if (AngleDelta > 0)
     this->mousebutton->setButton(event->inverted() ? SoMouseButtonEvent::BUTTON5 : SoMouseButtonEvent::BUTTON4);
-  else if (event->angleDelta().y() < 0)
+  else if (AngleDelta < 0)
     this->mousebutton->setButton(event->inverted() ? SoMouseButtonEvent::BUTTON4 : SoMouseButtonEvent::BUTTON5);
 #elif QT_VERSION >= 0x050000
   if (event->angleDelta().y() > 0)


### PR DESCRIPTION
The pull request implements a workaround for Qt issue [QTBUG-91556](https://bugreports.qt.io/browse/QTBUG-91556).

In Quarter widget the ALT key is used, to temporary switch the mode from interaction to navigation. In the current state, navigation works, except for zooming using the mouse wheel. This is caused by the mentioned issue. The pull request works around the issue by detecting if ALT key is down and if delta().y is 0 - this indicates that the axes are reversed.