### PR TITLE
CMake: Enable CMP0074 policy.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,11 @@ if(POLICY CMP0072)
   cmake_policy(SET CMP0072 NEW)
 endif()
 
+if(POLICY CMP0074)
+  # find_package() uses <PackageName>_ROOT variables.
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 # ############################################################################
 # Prevent in-source builds, as they often cause severe build problems
 # ############################################################################


### PR DESCRIPTION
From https://cmake.org/cmake/help/latest/policy/CMP0074.html.

---

[find_package()](https://cmake.org/cmake/help/latest/command/find_package.html#command:find_package) uses <PackageName>_ROOT variables.

In CMake 3.12 and above the [find_package(<PackageName>)](https://cmake.org/cmake/help/latest/command/find_package.html#command:find_package) command now searches prefixes specified by the [<PackageName>_ROOT](https://cmake.org/cmake/help/latest/variable/PackageName_ROOT.html#variable:%3CPackageName%3E_ROOT) CMake variable and the [<PackageName>_ROOT](https://cmake.org/cmake/help/latest/envvar/PackageName_ROOT.html#envvar:%3CPackageName%3E_ROOT) environment variable. Package roots are maintained as a stack so nested calls to all find_* commands inside find modules and config packages also search the roots as prefixes. This policy provides compatibility with projects that have not been updated to avoid using <PackageName>_ROOT variables for other purposes.

The OLD behavior for this policy is to ignore <PackageName>_ROOT variables. The NEW behavior for this policy is to use <PackageName>_ROOT variables.


